### PR TITLE
Spec cleanup

### DIFF
--- a/app/templates/base-rule-spec._coffee
+++ b/app/templates/base-rule-spec._coffee
@@ -11,12 +11,11 @@ describe '<%= ruleClass %>', ->
         # Anything will fail
       '''
       config =
-        <%= ruleUnderscored %>:
-          level: 'warn'
+        <%= ruleUnderscored %>: {}
 
       @errors = coffeelint.lint(lintyCode, config)
 
-    it 'has an error on line 1', ->
+    it 'has an warning on line 1', ->
       expect(@errors.length).toBe 1
       error = @errors[0]
       expect(error.level).toBe 'warn'

--- a/app/templates/base-rule-spec._coffee
+++ b/app/templates/base-rule-spec._coffee
@@ -1,4 +1,4 @@
-<%= ruleClass %> = require '../src/<%= pkgName %>'
+<%= ruleClass %> = require '../'
 
 coffeelint = require 'coffeelint'
 coffeelint.registerRule <%= ruleClass %>

--- a/app/templates/base-rule._coffee
+++ b/app/templates/base-rule._coffee
@@ -1,7 +1,7 @@
 class <%= ruleClass %>
   rule:
     name: '<%= ruleUnderscored %>'
-    level: 'error'
+    level: 'warn'
     message: '<%= ruleMessage %>'
     description: '<%= ruleDescription %>'
 


### PR DESCRIPTION
# Changes
- Requires in index.js in the generated spec.  This should help ensure that the generated module is valid.
- Generated specs default to `warn` instead of `error`.
