### PR TITLE
Fix broken contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yo coffeelint
 
 Contributing guidelines can be found [here][contributing-md].
 
-[contributing-md]: contributing.md
+[contributing-md]: CONTRIBUTING.md
 
 ## License
 


### PR DESCRIPTION
The link to the contributing markdown file was written incorrectly and led to a 404. This corrects the link.
